### PR TITLE
Feat: add machine to verify Transaction

### DIFF
--- a/machines/initialize-transaction.js
+++ b/machines/initialize-transaction.js
@@ -3,18 +3,13 @@ const { makeRequest } = require('../helpers/make-request')
 
 module.exports = {
 
-
   friendlyName: 'Initialize Transaction',
-
 
   description: 'Initialize a transaction from your backend',
 
-
   cacheable: false,
 
-
   sync: false,
-
 
   inputs: {
     apiKey: require('../constants/apiKey.input'),

--- a/machines/initialize-transaction.js
+++ b/machines/initialize-transaction.js
@@ -1,14 +1,20 @@
 const { getHeaders } = require('../helpers/get-headers')
 const { makeRequest } = require('../helpers/make-request')
+
 module.exports = {
+
 
   friendlyName: 'Initialize Transaction',
 
+
   description: 'Initialize a transaction from your backend',
+
 
   cacheable: false,
 
+
   sync: false,
+
 
   inputs: {
     apiKey: require('../constants/apiKey.input'),

--- a/machines/verify-transaction.js
+++ b/machines/verify-transaction.js
@@ -1,0 +1,44 @@
+const { getHeaders } = require('../helpers/get-headers')
+const { makeRequest } = require('../helpers/make-request')
+
+module.exports = {
+
+  friendlyName: 'Verify Transaction',
+
+  description: 'Confirm the status of a transaction',
+
+  cacheable: false,
+
+  sync: false,
+
+  inputs: {
+    apiKey: require('../constants/apiKey.input'),
+    reference: {
+      example: 'DG4uishudoq90LD',
+      description: 'The transaction reference used to intiate the transaction',
+      required: true
+    }
+  },
+
+  exits: {
+
+    success: {
+      description: 'Transaction verified successfully.',
+      outputFriendlyName: 'Verified transaction successfully'
+    }
+
+  },
+
+  fn: function ({ apiKey, reference }, exits) {
+    makeRequest(`/transaction/verify/${reference}`,
+      {
+        headers: getHeaders(apiKey || process.env.PAYSTACK_API_KEY)
+      }).then((retrievedTransaction) => {
+      return exits.success(retrievedTransaction)
+    }).catch(error => {
+      return exits.error(error)
+    })
+    return exits.success()
+  }
+
+}

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
       "list-subscriptions",
       "fetch-subscription",
       "enable-subscription",
-      "disable-subscription"
+      "disable-subscription",
+      "verify-transaction"
     ]
   },
   "husky": {

--- a/test/machines/verify-transaction.test.js
+++ b/test/machines/verify-transaction.test.js
@@ -1,0 +1,41 @@
+describe('Paystack.verifyTransaction()', () => {
+  it('Successfully Verify Transaction', (done) => {
+    const apiKey = process.env.PAYSTACK_API_KEY_FOR_TESTS
+    // create a brand new transaction
+    global.Paystack.initializeTransaction({
+      apiKey: apiKey,
+      email: 'customer@email.com',
+      amount: '20000'
+    }).exec(function (error, response) {
+      if (error) return done(error)
+      const refId = response.data.reference
+
+      global.Paystack.verifyTransaction({
+        apiKey: apiKey,
+        reference: refId
+      }).exec((error, response) => {
+        if (error) return done(error)
+
+        if (response) {
+          if (response.status) return done()
+          return done(new Error(response.message))
+        }
+      })
+    })
+  })
+
+  it('Failed to verify transaction with wrong reference Id', (done) => {
+    const wrongRef = 'wrong_ref_12'
+    global.Paystack.verifyTransaction({
+      apiKey: process.env.PAYSTACK_API_KEY_FOR_TESTS,
+      reference: wrongRef
+    }).exec(function (error, response) {
+      if (error) return done(error)
+
+      if (response) {
+        if (response.status === false) return done()
+        return done(new Error(response.message))
+      }
+    })
+  })
+})


### PR DESCRIPTION
Test: in this commit
--one passing test
--one failing test

❗ The changes you made to "initialize Transaction machine" resulted in an update in the former 'initialize transaction machine" that was already part of "verify Transaction machine" commit history.