### PR TITLE
Feat: add machine to Check transaction authorization.

### DIFF
--- a/machines/check-authorization.js
+++ b/machines/check-authorization.js
@@ -1,0 +1,60 @@
+const { getHeaders } = require('../helpers/get-headers')
+const { makeRequest } = require('../helpers/make-request')
+
+module.exports = {
+
+  friendlyName: 'Check Authorization',
+
+  description: 'All mastercard and visa authorizations can be checked with this endpoint to know if they have funds for the payment you seek.',
+
+  extendedDescription: 'This endpoint should be used when you do not know the exact amount to charge a card when rendering a service. It should be used to check if a card has enough funds based on a maximum range value. It is well suited for: 1. Ride hailing services 2. Logistics services',
+
+  cacheable: false,
+
+  sync: false,
+
+  inputs: {
+    apiKey: require('../constants/apiKey.input'),
+    amount: {
+      example: 5000,
+      description: 'Amount should be in kobo if currency is NGN and pesewas for GHS',
+      required: true
+    },
+    email: {
+      example: 'user@example.com',
+      description: 'Customer\'s email address',
+      required: true
+    },
+    authorization_code: {
+      example: 'AUTH_72btv547',
+      description: 'Valid authorization code to charge',
+      required: true
+    },
+    currency: {
+      example: 'NGN',
+      description: 'Currency in which amount should be charged'
+    }
+  },
+
+  exits: {
+
+    success: {
+      description: 'Authorization checked',
+      outputFriendlyName: 'Authorization checked'
+    }
+
+  },
+
+  fn: function ({ apiKey, ...bodyParams }, exits) {
+    makeRequest('/transaction/check_authorization', {
+      method: 'POST',
+      headers: getHeaders(apiKey || process.env.PAYSTACK_API_KEY),
+      body: JSON.stringify(bodyParams)
+    }).then((checkAuthorization) => {
+      return exits.success(checkAuthorization)
+    }).catch(error => {
+      return exits.error(error)
+    })
+  }
+
+}

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
       "verify-transaction",
       "list-transactions",
       "fetch-transaction",
-      "charge-authorization"
+      "charge-authorization",
+      "check-authorization"
     ]
   },
   "husky": {

--- a/test/machines/check-authorization.test.js
+++ b/test/machines/check-authorization.test.js
@@ -1,0 +1,29 @@
+describe('Paystack.checkAuthorization()', () => {
+  it('Successfully call check authorization endpoint', (done) => {
+    global.Paystack.checkAuthorization({
+      apiKey: global.apiKey,
+      authorization_code: 'AUTH_72btv547',
+      email: 'customers@email.com',
+      amount: 50000
+    }).exec((error, _) => {
+      if (error) return done(error)
+      return done()
+    })
+  })
+
+  it('Failed to check authorization with wrong authorization_code and email', (done) => {
+    global.Paystack.checkAuthorization({
+      apiKey: global.apiKey,
+      authorization_code: 'wrong authorization_code',
+      email: 'wrongcustomers@email.com',
+      amount: 20000
+    }).exec(function (error, response) {
+      if (error) return done(error)
+
+      if (response) {
+        if (response.status === false) return done()
+        return done(new Error(response.message))
+      }
+    })
+  })
+})


### PR DESCRIPTION
Test: 1 failing and 1 passing test

⚠️ since passing test case functionality could not be tested due to not finding a way to generate a valid authorization_code, it is merely testing if the endpoint gets hit successfully.